### PR TITLE
Lightbox: stage hugs the image (kill letterbox bands)

### DIFF
--- a/site/assets/css/gallery.css
+++ b/site/assets/css/gallery.css
@@ -139,13 +139,15 @@
   gap: var(--s-3);
   box-sizing: border-box;
 }
-/* Stage frames the image and clips zoomed overflow. The image is absolutely
-   positioned inside the stage so the JS can transform it freely without
-   reflowing the rest of the dialog. */
+/* Stage frames the image and clips zoomed overflow. Width/height are set per
+   image by JS to the image's fit-to-viewport dimensions at scale=1, so the
+   stage's rounded corners sit on the image edges with no letterbox bands.
+   max-width/max-height bound it to the visible viewport when JS hasn't run
+   yet (graceful degradation; lightbox is JS-driven anyway). */
 .lightbox-stage {
   position: relative;
-  width: 92vw;
-  height: 80vh;
+  max-width: 92vw;
+  max-height: 80vh;
   overflow: hidden;
   border-radius: var(--radius-lg);
   background: #0e0e0e;
@@ -251,7 +253,7 @@
   .gallery-item--wide { grid-column: span 2; }
   .gallery-item--tall { grid-row: span 2; }
   .lightbox-inner { padding: var(--s-3); }
-  .lightbox-stage { width: 96vw; height: 70vh; }
+  .lightbox-stage { max-width: 96vw; max-height: 70vh; }
   .lightbox-minimap { width: 120px; height: 80px; }
   .lightbox-prev { left: var(--s-2); }
   .lightbox-next { right: var(--s-2); }

--- a/site/assets/js/lightbox.js
+++ b/site/assets/js/lightbox.js
@@ -366,17 +366,30 @@
 
     function layoutImage() {
       if (!imgEl.naturalWidth) return;
-      var sr = stage.getBoundingClientRect();
-      stageW = sr.width;
-      stageH = sr.height;
-      var ratio = Math.min(stageW / imgEl.naturalWidth, stageH / imgEl.naturalHeight);
+      // Compute the image's fit-to-viewport size from CSS-equivalent
+      // viewport-percent caps. Using window dims directly (rather than the
+      // stage's rect) lets us size the stage to the image, so the stage's
+      // rounded corners hug the image edges and there are no black bands
+      // around tall portraits or wide landscapes. Mirrors the .lightbox-stage
+      // max-width/max-height in CSS plus the mobile breakpoint.
+      var isMobile = window.innerWidth <= 640;
+      var maxW = window.innerWidth * (isMobile ? 0.96 : 0.92);
+      var maxH = window.innerHeight * (isMobile ? 0.70 : 0.80);
+      var ratio = Math.min(maxW / imgEl.naturalWidth, maxH / imgEl.naturalHeight);
       natW = imgEl.naturalWidth * ratio;
       natH = imgEl.naturalHeight * ratio;
+      // Stage shrinks to the image (no letterbox); image fills the stage at
+      // scale=1 so tx/ty are zero. Zoom expands the image past the stage and
+      // overflow:hidden clips it.
+      stage.style.width = natW + "px";
+      stage.style.height = natH + "px";
+      stageW = natW;
+      stageH = natH;
       imgEl.style.width = natW + "px";
       imgEl.style.height = natH + "px";
       scale = 1;
-      tx = (stageW - natW) / 2;
-      ty = (stageH - natH) / 2;
+      tx = 0;
+      ty = 0;
       // Minimap reuses the same image as background; CSS `contain` letterboxes.
       minimap.style.backgroundImage = 'url("' + imgEl.src + '")';
       applyTransform();


### PR DESCRIPTION
## Summary
Tall portraits and ultra-wide landscapes were showing black bands in the lightbox because the `.lightbox-stage` was a fixed `92vw × 80vh` box with the image absolutely positioned + letterboxed inside. The stage's rounded corners sat on those black edges, making the image's own corners look square.

`layoutImage()` now sizes the stage to the image's fit-to-viewport dimensions at scale=1, so the rounded corners hug the image. CSS falls back to `max-width`/`max-height` when JS hasn't run.

## Test plan
- [x] Open a vertical image (e.g. `/gallery/maine-trip/`) — no black bands left/right
- [x] Open a horizontal image — no black bands top/bottom
- [x] Rounded corners visible on the image edges
- [x] Zoom + pan still works (stage clips overflow as before)
- [x] Mobile breakpoint (`max-width: 640px`) still respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)